### PR TITLE
Fixes for conversion between bitvectors and integers.

### DIFF
--- a/Logics/QF_BV.smt2
+++ b/Logics/QF_BV.smt2
@@ -4,10 +4,10 @@
  :smt-lib-release "2024-07-21"
  :written-by "Clark Barrett, Pascal Fontaine, Silvio Ranise, and Cesare Tinelli"
  :date "2010-05-02"
- :last-updated "2025-02-19"
+ :last-updated "2025-02-25"
  :update-history
  "Note: history only accounts for content changes, not release changes.
-  2025-02-19 Renamed and updated conversion operators to/from integers.
+  2025-02-25 Renamed and updated conversion operators to/from integers.
   2024-07-21 Updated to Version 2.7.
   2024-07-15 Added conversion operators between bitvectors and integers.
   2024-07-14 Minor disambiguation.
@@ -94,7 +94,7 @@
       - convert bitvector, interpreted as unsigned, to its integer value
     (sbv_to_int (_ BitVec m) Int)
       - convert a bitvector, interpreted as signed, to its integer value
-    ((_ bv_from_int m) (Int) (_ BitVec m))
+    ((_ int_to_bv m) (Int) (_ BitVec m))
       - convert an Integer to a bitvector
 
   Defined below:

--- a/Logics/QF_BV.smt2
+++ b/Logics/QF_BV.smt2
@@ -4,10 +4,10 @@
  :smt-lib-release "2024-07-21"
  :written-by "Clark Barrett, Pascal Fontaine, Silvio Ranise, and Cesare Tinelli"
  :date "2010-05-02"
- :last-updated "2025-02-16"
+ :last-updated "2025-02-19"
  :update-history
  "Note: history only accounts for content changes, not release changes.
-  2025-02-16 Renamed and updated conversion operators to/from integers.
+  2025-02-19 Renamed and updated conversion operators to/from integers.
   2024-07-21 Updated to Version 2.7.
   2024-07-15 Added conversion operators between bitvectors and integers.
   2024-07-14 Minor disambiguation.
@@ -90,11 +90,11 @@
       - overflow predicate for unsigned multiplication modulo 2^m
     (bvsmulo (_ BitVec m) (_ BitVec m) Bool)
       - overflow predicate for signed multiplication on m-bit 2's complement
-    (bv.ubv_to_int (_ BitVec m) Int)
+    (ubv_to_int (_ BitVec m) Int)
       - convert bitvector, interpreted as unsigned, to its integer value
-    (bv.sbv_to_int (_ BitVec m) Int)
+    (sbv_to_int (_ BitVec m) Int)
       - convert a bitvector, interpreted as signed, to its integer value
-    ((_ Int.to_bv m) (Int) (_ BitVec m))
+    ((_ bv_from_int m) (Int) (_ BitVec m))
       - convert an Integer to a bitvector
 
   Defined below:

--- a/Logics/QF_BV.smt2
+++ b/Logics/QF_BV.smt2
@@ -4,12 +4,13 @@
  :smt-lib-release "2024-07-21"
  :written-by "Clark Barrett, Pascal Fontaine, Silvio Ranise, and Cesare Tinelli"
  :date "2010-05-02"
- :last-updated "2024-07-21"
+ :last-updated "2025-02-16"
  :update-history
  "Note: history only accounts for content changes, not release changes.
+  2025-02-16 Renamed and updated conversion operators to/from integers.
   2024-07-21 Updated to Version 2.7.
-  2024-07-15 Added bv2nat, bv2int, nat2bv, int2bv
-  2024-07-14 Minor disambiguation
+  2024-07-15 Added conversion operators between bitvectors and integers.
+  2024-07-14 Minor disambiguation.
   2023-11-29 Added bvnego bvuaddo bvsaddo bvumulo bvsmulo bvusubo bvssubo bvsdivo
   2020-05-20 bvxnor is no longer marked as left associative, as that is
              inconsistent with its meaning as the negation of bvxor.
@@ -89,14 +90,12 @@
       - overflow predicate for unsigned multiplication modulo 2^m
     (bvsmulo (_ BitVec m) (_ BitVec m) Bool)
       - overflow predicate for signed multiplication on m-bit 2's complement
-    (bv2nat (_ BitVec m) Int)
+    (bv.ubv_to_int (_ BitVec m) Int)
       - convert bitvector, interpreted as unsigned, to its integer value
-    (bv2int (_ BitVec m) Int)
-      - convert a bitvector, interpreted as signed, to integer value
-    ((_ nat2bv m) (Int) (_ BitVec m))
-      - convert an Integer into an unsigned bitvector
-    ((_ int2bv m) (Int) (_ BitVec m))
-      - convert an Integer into a signed bitvector
+    (bv.sbv_to_int (_ BitVec m) Int)
+      - convert a bitvector, interpreted as signed, to its integer value
+    ((_ Int.to_bv m) (Int) (_ BitVec m))
+      - convert an Integer to a bitvector
 
   Defined below:
 

--- a/Theories/FixedSizeBitVectors.smt2
+++ b/Theories/FixedSizeBitVectors.smt2
@@ -4,10 +4,10 @@
  :smt-lib-release "2024-07-21"
  :written-by "Clark Barrett, Pascal Fontaine, Silvio Ranise, and Cesare Tinelli"
  :date "2010-05-02" 
- :last-updated "2025-02-16"
+ :last-updated "2025-02-19"
  :update-history
  "Note: history only accounts for content changes, not release changes.
-  2025-02-16 Renamed and updated conversion operators to/from integers.
+  2025-02-19 Renamed and updated conversion operators to/from integers.
   2024-07-21 Updated to Version 2.7.
   2024-07-16 Added conversion operators between bitvectors and integers.
   2024-07-14 Fixed minor typos.
@@ -90,11 +90,11 @@
  :funs_description "
    If the Ints theory is also present, all function symbols with declarations of the form
 
-       (bv.ubv_to_int (_ BitVec m) Int)
+       (ubv_to_int (_ BitVec m) Int)
     or
-       (bv.sbv_to_int (_ BitVec m) Int)
+       (sbv_to_int (_ BitVec m) Int)
     or
-       ((_ Int.to_bv m) Int (_ BitVec m))
+       ((_ bv_from_int m) Int (_ BitVec m))
 
     where
     - m is a numeral greater than 0.
@@ -240,21 +240,21 @@
    interprets them according to the semantics defined there.  We further
    define:
 
-   [[(bv.ubv_to_int s)]] := bv2nat([[s]])
+   [[(ubv_to_int s)]] := bv2nat([[s]])
 
-   [[(bv.sbv_to_int s)]] := if [[s]](m-1) = 0 then bv2nat([[s]])
-                                              else bv2nat([[s]]) - 2^m
+   [[(sbv_to_int s)]] := if [[s]](m-1) = 0 then bv2nat([[s]])
+                                           else bv2nat([[s]]) - 2^m
 
    where s is of sort (_ BitVec m) and 0 < m.  We also define:
 
-   [[((_ Int.to_bv N) x)]] := nat2bv[[[N]]]([[x]] mod 2^[[N]])
+   [[((_ bv_from_int N) x)]] := nat2bv[[[N]]]([[x]] mod 2^[[N]])
 
    where N is a numeral greater than 0 and x is a term of sort Int.
 
    Notice that the semantics are correct regardless of whether the intended
    target is a signed or unsigned bitvector.  For example:
 
-     [[((_ Int.to_bv 4) -7)]] = [[((_ Int.to_bv 4) 9)]] = 1001.
+     [[((_ bv_from_int 4) -7)]] = [[((_ bv_from_int 4) 9)]] = 1001.
 
    In both cases, the mod operation (as defined above to always return a
    nonnegative value) leads to the correct result.

--- a/Theories/FixedSizeBitVectors.smt2
+++ b/Theories/FixedSizeBitVectors.smt2
@@ -4,10 +4,10 @@
  :smt-lib-release "2024-07-21"
  :written-by "Clark Barrett, Pascal Fontaine, Silvio Ranise, and Cesare Tinelli"
  :date "2010-05-02" 
- :last-updated "2025-02-19"
+ :last-updated "2025-02-25"
  :update-history
  "Note: history only accounts for content changes, not release changes.
-  2025-02-19 Renamed and updated conversion operators to/from integers.
+  2025-02-25 Renamed and updated conversion operators to/from integers.
   2024-07-21 Updated to Version 2.7.
   2024-07-16 Added conversion operators between bitvectors and integers.
   2024-07-14 Fixed minor typos.
@@ -94,7 +94,7 @@
     or
        (sbv_to_int (_ BitVec m) Int)
     or
-       ((_ bv_from_int m) Int (_ BitVec m))
+       ((_ int_to_bv m) Int (_ BitVec m))
 
     where
     - m is a numeral greater than 0.
@@ -247,14 +247,14 @@
 
    where s is of sort (_ BitVec m) and 0 < m.  We also define:
 
-   [[((_ bv_from_int N) x)]] := nat2bv[[[N]]]([[x]] mod 2^[[N]])
+   [[((_ int_to_bv N) x)]] := nat2bv[[[N]]]([[x]] mod 2^[[N]])
 
    where N is a numeral greater than 0 and x is a term of sort Int.
 
    Notice that the semantics are correct regardless of whether the intended
    target is a signed or unsigned bitvector.  For example:
 
-     [[((_ bv_from_int 4) -7)]] = [[((_ bv_from_int 4) 9)]] = 1001.
+     [[((_ int_to_bv 4) -7)]] = [[((_ int_to_bv 4) 9)]] = 1001.
 
    In both cases, the mod operation (as defined above to always return a
    nonnegative value) leads to the correct result.


### PR DESCRIPTION
This updates and simplifies the conversion operators between bitvectors and integers.  There were several problems with the previous description.  The new version also uses updated names for the operators that are more consistent with the rest of SMT-LIB and with the upcoming version 3.